### PR TITLE
added nokia sros tfsm templates

### DIFF
--- a/textfsm_templates/nokia_sros_show_router_ospf_database_type_external_detail.template
+++ b/textfsm_templates/nokia_sros_show_router_ospf_database_type_external_detail.template
@@ -1,0 +1,25 @@
+Value Filldown ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Filldown PROCESS_ID (\d+)
+Value Filldown ADV_ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Required SUBNET (\d+\.\d+\.\d+\.\d+)
+Value Required SUBNET_MASK (\d+\.\d+\.\d+\.\d+)
+Value Filldown METRIC_TYPE (\d+)
+Value Filldown METRIC (\d+)
+Value Filldown FORWARDING_IP_ADDR (\d+\.\d+\.\d+\.\d+)
+
+
+
+Start
+  ^Rtr Base OSPFv2 Instance 0 Link State Database \(type: External\) \(detail\) -> Sep
+
+Sep
+  ^= -> Lsa
+
+Lsa
+  ^AS Ext LSA for Network -> Record
+  ^= -> EOF
+  ^.*Adv Router Id\s+: ${ADV_ROUTER_ID}
+  ^Link State Id\s+: ${SUBNET}
+  ^Network Mask\s+: ${SUBNET_MASK}\s+Fwding Address\s+: ${FORWARDING_IP_ADDR}
+  ^Metric Type\s+: Type ${METRIC_TYPE}\s+Metric-0\s+: ${METRIC}
+

--- a/textfsm_templates/nokia_sros_show_router_ospf_database_type_network_detail.template
+++ b/textfsm_templates/nokia_sros_show_router_ospf_database_type_network_detail.template
@@ -1,0 +1,21 @@
+Value AREA (\d+\.\d+\.\d+\.\d+|\d+)
+Value NETMASK (\d+\.\d+\.\d+\.\d+|\d+)
+Value ADV_ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Filldown DR_IP_Add (\d+\.\d+\.\d+\.\d+)
+Value List NEIGHBORING_ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+
+Start
+  ^Rtr Base OSPFv2 Instance \d+ Link State Database \(type: Network\) \(detail\) -> Sep
+
+Sep
+  ^= -> Lsa
+
+Lsa
+  ^Network LSA for Area -> Record
+  ^= -> EOF
+  ^Area Id\s+: ${AREA}\s+Adv Router Id\s+: ${ADV_ROUTER_ID}
+  ^Link State Id\s+: ${DR_IP_Add}
+  ^Network Mask\s+: ${NETMASK}
+  ^Router Id \(\d+\)\s+: ${NEIGHBORING_ROUTER_ID} -> Continue
+  ^Router Id.*Router Id \(\d+\)\s+: ${NEIGHBORING_ROUTER_ID} 
+

--- a/textfsm_templates/nokia_sros_show_router_ospf_database_type_router_detail_p2p.template
+++ b/textfsm_templates/nokia_sros_show_router_ospf_database_type_router_detail_p2p.template
@@ -1,0 +1,20 @@
+Value Filldown ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Filldown PROCESS_ID (\d+)
+Value Filldown AREA (\d+\.\d+\.\d+\.\d+|\d+)
+Value Filldown ADV_ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Required STUB (Point To Point)
+Value Required NEIGHBORING_ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Required METRIC (\d+)
+
+Start
+  ^Area Id\s+: ${AREA}\s+Adv Router Id\s+: ${ADV_ROUTER_ID}
+  ^Link Type \(\d+\)\s+: ${STUB}
+  ^Nbr Rtr Id \(\d+\)\s+: ${NEIGHBORING_ROUTER_ID} 
+  ^No of TOS \(\d+\)\s+: 0\s+Metric-0 \(\d+\)\s+: ${METRIC} -> Record
+  ^- -> Tag
+  
+Tag
+  ^Router LSA for Area -> Next.Clearall
+  ^- -> Start
+  
+EOF

--- a/textfsm_templates/nokia_sros_show_router_ospf_database_type_router_detail_stub.template
+++ b/textfsm_templates/nokia_sros_show_router_ospf_database_type_router_detail_stub.template
@@ -1,0 +1,21 @@
+Value Filldown ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Filldown PROCESS_ID (\d+)
+Value Filldown AREA (\d+\.\d+\.\d+\.\d+|\d+)
+Value Filldown ADV_ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Required STUB (Stub Network)
+Value SUBNET (\d+\.\d+\.\d+\.\d+)
+Value SUBNET_MASK (\d+\.\d+\.\d+\.\d+)
+Value Required METRIC (\d+)
+
+Start
+  ^Area Id\s+: ${AREA}\s+Adv Router Id\s+: ${ADV_ROUTER_ID}
+  ^Link Type \(\d+\)\s+: ${STUB}
+  ^Network \(\d+\)\s+: ${SUBNET}\s+ Mask \(\d+\)\s+: ${SUBNET_MASK} 
+  ^No of TOS \(\d+\)\s+: 0\s+Metric-0 \(\d+\)\s+: ${METRIC} -> Record
+  ^- -> Tag
+  
+Tag
+  ^Router LSA for Area -> Next.Clearall
+  ^- -> Start
+  
+EOF

--- a/textfsm_templates/nokia_sros_show_router_ospf_database_type_router_detail_transit.template
+++ b/textfsm_templates/nokia_sros_show_router_ospf_database_type_router_detail_transit.template
@@ -1,0 +1,21 @@
+Value Filldown ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Filldown PROCESS_ID (\d+)
+Value Filldown AREA (\d+\.\d+\.\d+\.\d+|\d+)
+Value Filldown ADV_ROUTER_ID (\d+\.\d+\.\d+\.\d+)
+Value Required STUB (Transit Network)
+Value DR_IP_Addr (\d+\.\d+\.\d+\.\d+)
+Value ROUTER_INTERFACE_IP (\d+\.\d+\.\d+\.\d+)
+Value Required METRIC (\d+)
+
+Start
+  ^Area Id\s+: ${AREA}\s+Adv Router Id\s+: ${ADV_ROUTER_ID}
+  ^Link Type \(\d+\)\s+: ${STUB}
+  ^DR Rtr Id \(\d+\)\s+: ${DR_IP_Addr}\s+ I/F Address \(\d+\)\s+: ${ROUTER_INTERFACE_IP} 
+  ^No of TOS \(\d+\)\s+: 0\s+Metric-0 \(\d+\)\s+: ${METRIC} -> Record
+  ^- -> Tag
+  
+Tag
+  ^Router LSA for Area -> Next.Clearall
+  ^- -> Start
+  
+EOF


### PR DESCRIPTION
Nokia SR OS TextFSM templates. OSPF DB can be extracted from an SR OS node with the following `show` commands:

```
show router ospf database type router detail
show router ospf database type network detail
show router ospf database type external detail
```